### PR TITLE
feat: integrate GroupBuy bot frontend into Mattermost webapp

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-29T12:58:55.115Z for PR creation at branch issue-7-cab98f75f9c0 for issue https://github.com/MixaByk1996/mattermost/issues/7

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-29T12:58:55.115Z for PR creation at branch issue-7-cab98f75f9c0 for issue https://github.com/MixaByk1996/mattermost/issues/7

--- a/mattermost-master/webapp/channels/src/components/groupbuy/groupbuy.scss
+++ b/mattermost-master/webapp/channels/src/components/groupbuy/groupbuy.scss
@@ -1,0 +1,968 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* GroupBuy Bot - Telegram-like Design System */
+
+.groupbuy-app {
+    // CSS Variables - Telegram Color Palette
+    --tg-primary: #2481cc;
+    --tg-primary-dark: #1b6aaa;
+    --tg-primary-light: #4aa3df;
+
+    --tg-bg-primary: #ffffff;
+    --tg-bg-secondary: #f0f2f5;
+    --tg-bg-tertiary: #e6ebee;
+    --tg-bg-chat: #e8dfd8;
+
+    --tg-text-primary: #000000;
+    --tg-text-secondary: #707579;
+    --tg-text-muted: #8d969c;
+    --tg-text-link: #2481cc;
+
+    --tg-msg-outgoing: #effdde;
+    --tg-msg-incoming: #ffffff;
+    --tg-msg-system: #fffce1;
+
+    --tg-online: #4fae4e;
+    --tg-error: #df3f40;
+    --tg-warning: #f5a623;
+    --tg-success: #4fae4e;
+
+    --tg-border: #dadce0;
+    --tg-border-light: #e8e8e8;
+
+    --tg-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    --tg-shadow-medium: 0 2px 8px rgba(0, 0, 0, 0.15);
+    --tg-shadow-large: 0 4px 16px rgba(0, 0, 0, 0.2);
+
+    --tg-transition: 0.2s ease;
+
+    --tg-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    --tg-font-size-xs: 11px;
+    --tg-font-size-sm: 12px;
+    --tg-font-size-base: 14px;
+    --tg-font-size-md: 15px;
+    --tg-font-size-lg: 16px;
+    --tg-font-size-xl: 18px;
+    --tg-font-size-xxl: 20px;
+
+    --tg-spacing-xs: 4px;
+    --tg-spacing-sm: 8px;
+    --tg-spacing-md: 12px;
+    --tg-spacing-lg: 16px;
+    --tg-spacing-xl: 24px;
+
+    --tg-radius-sm: 4px;
+    --tg-radius-md: 8px;
+    --tg-radius-lg: 12px;
+    --tg-radius-xl: 18px;
+    --tg-radius-round: 50%;
+
+    --tg-sidebar-width: 300px;
+    --tg-header-height: 56px;
+    --tg-input-height: 44px;
+    --tg-avatar-sm: 32px;
+    --tg-avatar-md: 42px;
+    --tg-avatar-lg: 54px;
+
+    // Dark theme
+    &[data-theme="dark"] {
+        --tg-bg-primary: #17212b;
+        --tg-bg-secondary: #232e3c;
+        --tg-bg-tertiary: #1e2c3a;
+        --tg-bg-chat: #0e1621;
+
+        --tg-text-primary: #ffffff;
+        --tg-text-secondary: #8d969c;
+        --tg-text-muted: #6d7f8f;
+
+        --tg-msg-outgoing: #2b5278;
+        --tg-msg-incoming: #182533;
+
+        --tg-border: #2f3b47;
+        --tg-border-light: #3a4654;
+    }
+
+    // Layout
+    display: flex;
+    height: 100%;
+    font-family: var(--tg-font-family);
+    font-size: var(--tg-font-size-base);
+    line-height: 1.4;
+    color: var(--tg-text-primary);
+    background-color: var(--tg-bg-secondary);
+    overflow: hidden;
+
+    // Sidebar
+    .gb-sidebar {
+        width: var(--tg-sidebar-width);
+        min-width: var(--tg-sidebar-width);
+        background-color: var(--tg-bg-primary);
+        border-right: 1px solid var(--tg-border);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    // Main content area
+    .gb-main-content {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        background-color: var(--tg-bg-chat);
+        overflow: hidden;
+    }
+
+    // Header
+    .gb-header {
+        height: var(--tg-header-height);
+        background-color: var(--tg-bg-primary);
+        border-bottom: 1px solid var(--tg-border);
+        display: flex;
+        align-items: center;
+        padding: 0 var(--tg-spacing-lg);
+        gap: var(--tg-spacing-md);
+        flex-shrink: 0;
+    }
+
+    .gb-header-title {
+        font-size: var(--tg-font-size-lg);
+        font-weight: 500;
+        color: var(--tg-text-primary);
+        flex: 1;
+    }
+
+    .gb-header-subtitle {
+        font-size: var(--tg-font-size-sm);
+        color: var(--tg-text-secondary);
+    }
+
+    // Buttons
+    .gb-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        border: none;
+        outline: none;
+        font-family: var(--tg-font-family);
+        transition: background-color var(--tg-transition);
+
+        &.gb-btn-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: var(--tg-radius-round);
+            background-color: transparent;
+            color: var(--tg-text-secondary);
+            flex-shrink: 0;
+
+            &:hover {
+                background-color: var(--tg-bg-secondary);
+            }
+        }
+
+        &.gb-btn-primary {
+            padding: var(--tg-spacing-sm) var(--tg-spacing-xl);
+            background-color: var(--tg-primary);
+            color: #ffffff;
+            border-radius: var(--tg-radius-xl);
+            font-size: var(--tg-font-size-base);
+            font-weight: 500;
+
+            &:hover {
+                background-color: var(--tg-primary-dark);
+            }
+        }
+
+        &.gb-btn-secondary {
+            padding: var(--tg-spacing-sm) var(--tg-spacing-xl);
+            background-color: var(--tg-bg-secondary);
+            color: var(--tg-text-primary);
+            border-radius: var(--tg-radius-xl);
+            font-size: var(--tg-font-size-base);
+
+            &:hover {
+                background-color: var(--tg-bg-tertiary);
+            }
+        }
+    }
+
+    // Search bar
+    .gb-search-bar {
+        position: relative;
+        padding: var(--tg-spacing-sm) var(--tg-spacing-md);
+        flex-shrink: 0;
+    }
+
+    .gb-search-input {
+        width: 100%;
+        height: 36px;
+        padding: 0 var(--tg-spacing-md) 0 36px;
+        background-color: var(--tg-bg-secondary);
+        border-radius: var(--tg-radius-xl);
+        font-size: var(--tg-font-size-base);
+        color: var(--tg-text-primary);
+        border: none;
+        outline: none;
+        font-family: var(--tg-font-family);
+
+        &::placeholder {
+            color: var(--tg-text-muted);
+        }
+    }
+
+    .gb-search-icon {
+        position: absolute;
+        left: 24px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--tg-text-muted);
+        width: 20px;
+        height: 20px;
+    }
+
+    // Tabs
+    .gb-tabs {
+        display: flex;
+        border-bottom: 1px solid var(--tg-border);
+        background-color: var(--tg-bg-primary);
+        flex-shrink: 0;
+    }
+
+    .gb-tab {
+        flex: 1;
+        padding: var(--tg-spacing-md);
+        text-align: center;
+        font-size: var(--tg-font-size-base);
+        font-weight: 500;
+        color: var(--tg-text-secondary);
+        cursor: pointer;
+        position: relative;
+        transition: color var(--tg-transition);
+        background: transparent;
+        border: none;
+        font-family: var(--tg-font-family);
+
+        &:hover {
+            color: var(--tg-text-primary);
+        }
+
+        &.active {
+            color: var(--tg-primary);
+
+            &::after {
+                content: '';
+                position: absolute;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                height: 2px;
+                background-color: var(--tg-primary);
+            }
+        }
+    }
+
+    // Chat list
+    .gb-chat-list {
+        flex: 1;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    .gb-chat-item {
+        display: flex;
+        align-items: center;
+        padding: var(--tg-spacing-sm) var(--tg-spacing-md);
+        gap: var(--tg-spacing-md);
+        cursor: pointer;
+        transition: background-color var(--tg-transition);
+
+        &:hover {
+            background-color: var(--tg-bg-secondary);
+        }
+
+        &.active {
+            background-color: var(--tg-primary);
+
+            .gb-chat-title,
+            .gb-chat-message,
+            .gb-chat-time {
+                color: #ffffff;
+            }
+        }
+    }
+
+    .gb-chat-avatar {
+        width: var(--tg-avatar-lg);
+        height: var(--tg-avatar-lg);
+        border-radius: var(--tg-radius-round);
+        background-color: var(--tg-primary);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #ffffff;
+        font-size: var(--tg-font-size-xl);
+        font-weight: 500;
+        flex-shrink: 0;
+    }
+
+    .gb-chat-info {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+    }
+
+    .gb-chat-header-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 2px;
+    }
+
+    .gb-chat-title {
+        font-size: var(--tg-font-size-md);
+        font-weight: 500;
+        color: var(--tg-text-primary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .gb-chat-time {
+        font-size: var(--tg-font-size-xs);
+        color: var(--tg-text-muted);
+        flex-shrink: 0;
+        margin-left: var(--tg-spacing-sm);
+    }
+
+    .gb-chat-message {
+        font-size: var(--tg-font-size-base);
+        color: var(--tg-text-secondary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .gb-chat-badge {
+        min-width: 20px;
+        height: 20px;
+        padding: 0 6px;
+        background-color: var(--tg-primary);
+        border-radius: 10px;
+        color: #ffffff;
+        font-size: var(--tg-font-size-xs);
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    // Procurement slider
+    .gb-procurement-slider {
+        background-color: var(--tg-bg-primary);
+        border-bottom: 1px solid var(--tg-border);
+        padding: var(--tg-spacing-md);
+        flex-shrink: 0;
+    }
+
+    .gb-slider-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: var(--tg-spacing-sm);
+    }
+
+    .gb-slider-title {
+        font-size: var(--tg-font-size-sm);
+        font-weight: 600;
+        color: var(--tg-text-secondary);
+        text-transform: uppercase;
+    }
+
+    .gb-slider-nav {
+        display: flex;
+        gap: var(--tg-spacing-xs);
+    }
+
+    .gb-slider-nav-btn {
+        width: 28px;
+        height: 28px;
+        border-radius: var(--tg-radius-round);
+        background-color: var(--tg-bg-secondary);
+        border: none;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--tg-text-secondary);
+        transition: background-color var(--tg-transition), color var(--tg-transition);
+
+        &:hover:not(:disabled) {
+            background-color: var(--tg-primary);
+            color: #ffffff;
+        }
+
+        &:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+    }
+
+    .gb-slider-wrapper {
+        position: relative;
+    }
+
+    .gb-slider-container {
+        display: flex;
+        gap: var(--tg-spacing-md);
+        overflow-x: auto;
+        padding-bottom: var(--tg-spacing-sm);
+        scrollbar-width: thin;
+        scrollbar-color: var(--tg-border) transparent;
+        scroll-behavior: smooth;
+
+        &::-webkit-scrollbar {
+            height: 4px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background-color: var(--tg-border);
+            border-radius: 2px;
+        }
+    }
+
+    .gb-procurement-card {
+        min-width: 200px;
+        max-width: 200px;
+        background-color: var(--tg-bg-secondary);
+        border-radius: var(--tg-radius-lg);
+        padding: var(--tg-spacing-md);
+        cursor: pointer;
+        transition: transform var(--tg-transition), box-shadow var(--tg-transition);
+        flex-shrink: 0;
+
+        &:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--tg-shadow-medium);
+        }
+    }
+
+    .gb-procurement-title {
+        font-size: var(--tg-font-size-base);
+        font-weight: 500;
+        color: var(--tg-text-primary);
+        margin-bottom: var(--tg-spacing-xs);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .gb-procurement-info {
+        font-size: var(--tg-font-size-sm);
+        color: var(--tg-text-secondary);
+        margin-bottom: var(--tg-spacing-sm);
+    }
+
+    .gb-procurement-progress {
+        height: 4px;
+        background-color: var(--tg-border);
+        border-radius: 2px;
+        overflow: hidden;
+    }
+
+    .gb-procurement-progress-bar {
+        height: 100%;
+        background-color: var(--tg-primary);
+        border-radius: 2px;
+        transition: width 0.3s ease;
+    }
+
+    .gb-procurement-stats {
+        display: flex;
+        justify-content: space-between;
+        margin-top: var(--tg-spacing-xs);
+        font-size: var(--tg-font-size-xs);
+        color: var(--tg-text-muted);
+    }
+
+    // Message area
+    .gb-message-area {
+        flex: 1;
+        overflow-y: auto;
+        padding: var(--tg-spacing-lg);
+        display: flex;
+        flex-direction: column;
+        gap: var(--tg-spacing-sm);
+    }
+
+    .gb-message {
+        max-width: 70%;
+        padding: var(--tg-spacing-sm) var(--tg-spacing-md);
+        border-radius: var(--tg-radius-lg);
+        position: relative;
+        word-wrap: break-word;
+
+        &.incoming {
+            align-self: flex-start;
+            background-color: var(--tg-msg-incoming);
+            border-bottom-left-radius: var(--tg-radius-sm);
+        }
+
+        &.outgoing {
+            align-self: flex-end;
+            background-color: var(--tg-msg-outgoing);
+            border-bottom-right-radius: var(--tg-radius-sm);
+        }
+
+        &.system {
+            align-self: center;
+            background-color: var(--tg-msg-system);
+            font-size: var(--tg-font-size-sm);
+            color: var(--tg-text-secondary);
+            max-width: 80%;
+            text-align: center;
+        }
+    }
+
+    .gb-message-sender {
+        font-size: var(--tg-font-size-xs);
+        font-weight: 600;
+        color: var(--tg-primary);
+        margin-bottom: 2px;
+    }
+
+    .gb-message-text {
+        font-size: var(--tg-font-size-base);
+        color: var(--tg-text-primary);
+        line-height: 1.5;
+
+        a {
+            color: var(--tg-text-link);
+        }
+    }
+
+    .gb-message-time {
+        font-size: var(--tg-font-size-xs);
+        color: var(--tg-text-muted);
+        text-align: right;
+        margin-top: 2px;
+    }
+
+    .gb-message-date-divider {
+        align-self: center;
+        padding: var(--tg-spacing-xs) var(--tg-spacing-md);
+        background-color: rgba(0, 0, 0, 0.1);
+        border-radius: 10px;
+        font-size: var(--tg-font-size-xs);
+        color: var(--tg-text-secondary);
+        margin: var(--tg-spacing-sm) 0;
+    }
+
+    // Message input area
+    .gb-message-input-area {
+        display: flex;
+        align-items: flex-end;
+        padding: var(--tg-spacing-sm) var(--tg-spacing-md);
+        background-color: var(--tg-bg-primary);
+        border-top: 1px solid var(--tg-border);
+        gap: var(--tg-spacing-sm);
+        flex-shrink: 0;
+    }
+
+    .gb-message-input-container {
+        flex: 1;
+        background-color: var(--tg-bg-secondary);
+        border-radius: var(--tg-radius-xl);
+        padding: var(--tg-spacing-sm) var(--tg-spacing-md);
+    }
+
+    .gb-message-input {
+        width: 100%;
+        background: transparent;
+        border: none;
+        outline: none;
+        font-size: var(--tg-font-size-base);
+        color: var(--tg-text-primary);
+        resize: none;
+        font-family: var(--tg-font-family);
+        max-height: 150px;
+        overflow-y: auto;
+
+        &::placeholder {
+            color: var(--tg-text-muted);
+        }
+    }
+
+    .gb-send-button {
+        width: 44px;
+        height: 44px;
+        border-radius: var(--tg-radius-round);
+        background-color: var(--tg-primary);
+        border: none;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #ffffff;
+        flex-shrink: 0;
+        transition: background-color var(--tg-transition);
+
+        &:hover {
+            background-color: var(--tg-primary-dark);
+        }
+    }
+
+    // Welcome screen
+    .gb-welcome-screen {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        color: var(--tg-text-muted);
+
+        h2 {
+            margin-top: var(--tg-spacing-lg);
+            color: var(--tg-text-secondary);
+            font-size: var(--tg-font-size-xl);
+        }
+
+        p {
+            margin-top: var(--tg-spacing-sm);
+            font-size: var(--tg-font-size-base);
+        }
+    }
+
+    // Cabinet
+    .gb-cabinet {
+        flex: 1;
+        overflow-y: auto;
+    }
+
+    .gb-cabinet-header {
+        display: flex;
+        align-items: center;
+        gap: var(--tg-spacing-md);
+        padding: var(--tg-spacing-lg);
+        border-bottom: 1px solid var(--tg-border);
+    }
+
+    .gb-cabinet-avatar {
+        width: 60px;
+        height: 60px;
+        border-radius: var(--tg-radius-round);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #ffffff;
+        font-size: var(--tg-font-size-xxl);
+        font-weight: 500;
+    }
+
+    .gb-cabinet-name {
+        font-size: var(--tg-font-size-lg);
+        font-weight: 500;
+        color: var(--tg-text-primary);
+    }
+
+    .gb-cabinet-role {
+        font-size: var(--tg-font-size-sm);
+        color: var(--tg-text-secondary);
+    }
+
+    .gb-cabinet-balance {
+        padding: var(--tg-spacing-lg);
+        background-color: var(--tg-bg-primary);
+        margin: var(--tg-spacing-md);
+        border-radius: var(--tg-radius-lg);
+        box-shadow: var(--tg-shadow);
+    }
+
+    .gb-balance-label {
+        font-size: var(--tg-font-size-sm);
+        color: var(--tg-text-secondary);
+    }
+
+    .gb-balance-amount {
+        font-size: var(--tg-font-size-xxl);
+        font-weight: 600;
+        color: var(--tg-text-primary);
+        margin: var(--tg-spacing-xs) 0;
+    }
+
+    .gb-balance-actions {
+        display: flex;
+        gap: var(--tg-spacing-sm);
+        margin-top: var(--tg-spacing-md);
+    }
+
+    .gb-cabinet-menu {
+        margin: var(--tg-spacing-md);
+        border-radius: var(--tg-radius-lg);
+        background-color: var(--tg-bg-primary);
+        overflow: hidden;
+        box-shadow: var(--tg-shadow);
+    }
+
+    .gb-cabinet-menu-item {
+        display: flex;
+        align-items: center;
+        padding: var(--tg-spacing-lg);
+        gap: var(--tg-spacing-md);
+        cursor: pointer;
+        transition: background-color var(--tg-transition);
+        border-bottom: 1px solid var(--tg-border-light);
+
+        &:last-child {
+            border-bottom: none;
+        }
+
+        &:hover {
+            background-color: var(--tg-bg-secondary);
+        }
+    }
+
+    .gb-cabinet-menu-icon {
+        width: 24px;
+        height: 24px;
+        color: var(--tg-primary);
+    }
+
+    .gb-cabinet-menu-text {
+        flex: 1;
+        font-size: var(--tg-font-size-md);
+        color: var(--tg-text-primary);
+    }
+
+    // Modal
+    .gb-modal-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(0, 0, 0, 0.5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity var(--tg-transition), visibility var(--tg-transition);
+
+        &.active {
+            opacity: 1;
+            visibility: visible;
+
+            .gb-modal {
+                transform: scale(1);
+            }
+        }
+    }
+
+    .gb-modal {
+        background-color: var(--tg-bg-primary);
+        border-radius: var(--tg-radius-lg);
+        max-width: 420px;
+        width: 90%;
+        max-height: 90vh;
+        overflow-y: auto;
+        transform: scale(0.9);
+        transition: transform var(--tg-transition);
+    }
+
+    .gb-modal-header {
+        padding: var(--tg-spacing-lg);
+        border-bottom: 1px solid var(--tg-border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .gb-modal-title {
+        font-size: var(--tg-font-size-lg);
+        font-weight: 500;
+        color: var(--tg-text-primary);
+    }
+
+    .gb-modal-body {
+        padding: var(--tg-spacing-lg);
+    }
+
+    .gb-modal-footer {
+        padding: var(--tg-spacing-lg);
+        border-top: 1px solid var(--tg-border);
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--tg-spacing-sm);
+    }
+
+    // Forms
+    .gb-form-group {
+        margin-bottom: var(--tg-spacing-md);
+    }
+
+    .gb-form-label {
+        display: block;
+        font-size: var(--tg-font-size-sm);
+        color: var(--tg-text-secondary);
+        margin-bottom: var(--tg-spacing-xs);
+        font-weight: 500;
+    }
+
+    .gb-form-input {
+        width: 100%;
+        height: var(--tg-input-height);
+        padding: 0 var(--tg-spacing-md);
+        background-color: var(--tg-bg-secondary);
+        border-radius: var(--tg-radius-md);
+        font-size: var(--tg-font-size-base);
+        color: var(--tg-text-primary);
+        border: 1px solid var(--tg-border);
+        outline: none;
+        font-family: var(--tg-font-family);
+        transition: border-color var(--tg-transition);
+
+        &:focus {
+            border-color: var(--tg-primary);
+        }
+
+        &::placeholder {
+            color: var(--tg-text-muted);
+        }
+    }
+
+    // Toast notification
+    .gb-toast-container {
+        position: fixed;
+        bottom: var(--tg-spacing-xl);
+        right: var(--tg-spacing-xl);
+        z-index: 2000;
+        display: flex;
+        flex-direction: column;
+        gap: var(--tg-spacing-sm);
+    }
+
+    .gb-toast {
+        padding: var(--tg-spacing-md) var(--tg-spacing-lg);
+        border-radius: var(--tg-radius-md);
+        color: #ffffff;
+        font-size: var(--tg-font-size-base);
+        box-shadow: var(--tg-shadow-medium);
+        animation: gb-slideIn 0.3s ease;
+
+        &.info { background-color: var(--tg-primary); }
+        &.success { background-color: var(--tg-success); }
+        &.error { background-color: var(--tg-error); }
+        &.warning { background-color: var(--tg-warning); }
+    }
+
+    // Status badge
+    .gb-status-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 8px;
+        border-radius: 10px;
+        font-size: var(--tg-font-size-xs);
+        font-weight: 500;
+
+        &.status-active {
+            background-color: rgba(79, 174, 78, 0.1);
+            color: var(--tg-success);
+        }
+
+        &.status-pending,
+        &.status-draft {
+            background-color: rgba(245, 166, 35, 0.1);
+            color: var(--tg-warning);
+        }
+
+        &.status-completed {
+            background-color: rgba(36, 129, 204, 0.1);
+            color: var(--tg-primary);
+        }
+
+        &.status-cancelled {
+            background-color: rgba(223, 63, 64, 0.1);
+            color: var(--tg-error);
+        }
+    }
+
+    // Typing indicator
+    .gb-typing-indicator {
+        display: flex;
+        gap: 4px;
+        padding: var(--tg-spacing-sm);
+        align-self: flex-start;
+
+        span {
+            width: 8px;
+            height: 8px;
+            border-radius: var(--tg-radius-round);
+            background-color: var(--tg-text-muted);
+            animation: gb-pulse 1.4s infinite;
+
+            &:nth-child(2) { animation-delay: 0.2s; }
+            &:nth-child(3) { animation-delay: 0.4s; }
+        }
+    }
+
+    // Loading
+    .gb-loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--tg-spacing-xl);
+        color: var(--tg-text-muted);
+    }
+
+    // Responsive
+    @media (max-width: 768px) {
+        .gb-sidebar {
+            position: fixed;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            z-index: 100;
+            transform: translateX(-100%);
+            transition: transform var(--tg-transition);
+
+            &.open {
+                transform: translateX(0);
+            }
+        }
+
+        .gb-main-content {
+            width: 100%;
+        }
+
+        .gb-message {
+            max-width: 85%;
+        }
+
+        .gb-procurement-card {
+            min-width: 160px;
+            max-width: 160px;
+        }
+    }
+
+    // Animations
+    @keyframes gb-fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+    }
+
+    @keyframes gb-slideIn {
+        from { transform: translateY(20px); opacity: 0; }
+        to { transform: translateY(0); opacity: 1; }
+    }
+
+    @keyframes gb-pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+    }
+}

--- a/mattermost-master/webapp/channels/src/components/groupbuy/groupbuy.tsx
+++ b/mattermost-master/webapp/channels/src/components/groupbuy/groupbuy.tsx
@@ -1,0 +1,1343 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+
+import type {AppStateType, Message, Procurement, User} from './types';
+
+import './groupbuy.scss';
+
+// --- Utilities ---
+
+function formatTime(date: string): string {
+    const d = new Date(date);
+    const now = new Date();
+    const isToday = d.toDateString() === now.toDateString();
+
+    if (isToday) {
+        return d.toLocaleTimeString('ru-RU', {hour: '2-digit', minute: '2-digit'});
+    }
+
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+    if (d.toDateString() === yesterday.toDateString()) {
+        return 'Вчера';
+    }
+
+    return d.toLocaleDateString('ru-RU', {day: '2-digit', month: '2-digit'});
+}
+
+function formatCurrency(amount: number): string {
+    return new Intl.NumberFormat('ru-RU', {
+        style: 'currency',
+        currency: 'RUB',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+    }).format(amount);
+}
+
+function getInitials(firstName: string, lastName = ''): string {
+    const first = firstName ? firstName.charAt(0).toUpperCase() : '';
+    const last = lastName ? lastName.charAt(0).toUpperCase() : '';
+    return first + last || '?';
+}
+
+function getAvatarColor(name: string): string {
+    const colors = [
+        '#e17076', '#faa774', '#a695e7', '#7bc862',
+        '#6ec9cb', '#65aadd', '#ee7aae', '#f5a623',
+    ];
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+        hash = name.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return colors[Math.abs(hash) % colors.length];
+}
+
+function getStatusText(status: string): string {
+    const statuses: Record<string, string> = {
+        draft: 'Черновик',
+        active: 'Активная',
+        stopped: 'Остановлена',
+        payment: 'Оплата',
+        completed: 'Завершена',
+        cancelled: 'Отменена',
+    };
+    return statuses[status] || status;
+}
+
+function getRoleText(role: string): string {
+    const roles: Record<string, string> = {
+        buyer: 'Покупатель',
+        organizer: 'Организатор',
+        supplier: 'Поставщик',
+    };
+    return roles[role] || role;
+}
+
+// --- API Client ---
+
+const CONFIG = {
+    API_URL: '/api',
+};
+
+async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    const url = `${CONFIG.API_URL}${endpoint}`;
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+    };
+
+    const token = localStorage.getItem('groupbuy_authToken');
+    if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(url, {
+        ...options,
+        headers: {
+            ...headers,
+            ...(options.headers as Record<string, string> || {}),
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json();
+}
+
+const API = {
+    getUser: (userId: number) => apiRequest<User>(`/groupbuy/users/${userId}/`),
+    getProcurements: (params: Record<string, string> = {}) => {
+        const query = new URLSearchParams(params).toString();
+        return apiRequest<{results?: Procurement[]} | Procurement[]>(`/groupbuy/procurements/?${query}`);
+    },
+    getProcurement: (id: number) => apiRequest<Procurement>(`/groupbuy/procurements/${id}/`),
+    createProcurement: (data: Partial<Procurement>) => apiRequest<Procurement>('/groupbuy/procurements/', {
+        method: 'POST',
+        body: JSON.stringify(data),
+    }),
+    joinProcurement: (id: number, data: Record<string, unknown>) => apiRequest(`/groupbuy/procurements/${id}/join/`, {
+        method: 'POST',
+        body: JSON.stringify(data),
+    }),
+    registerUser: (data: Partial<User> & {platform?: string}) => apiRequest<User>('/groupbuy/users/', {
+        method: 'POST',
+        body: JSON.stringify(data),
+    }),
+    getMessages: (procurementId: number, params: Record<string, string> = {}) => {
+        const query = new URLSearchParams(params).toString();
+        return apiRequest<{results?: Message[]} | Message[]>(`/groupbuy/chat/messages/?procurement=${procurementId}&${query}`);
+    },
+    sendMessage: (data: Partial<Message>) => apiRequest<Message>('/groupbuy/chat/messages/', {
+        method: 'POST',
+        body: JSON.stringify(data),
+    }),
+    deposit: (userId: number, amount: number) => apiRequest(`/groupbuy/payments/`, {
+        method: 'POST',
+        body: JSON.stringify({user: userId, amount, type: 'deposit'}),
+    }),
+};
+
+// --- ProcurementSlider Component ---
+
+interface ProcurementSliderProps {
+    procurements: Procurement[];
+    onCardClick: (id: number) => void;
+}
+
+const SCROLL_STEP = 220;
+
+const ProcurementSlider: React.FC<ProcurementSliderProps> = ({procurements, onCardClick}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [canScrollLeft, setCanScrollLeft] = useState(false);
+    const [canScrollRight, setCanScrollRight] = useState(false);
+
+    const updateScrollButtons = useCallback(() => {
+        const el = containerRef.current;
+        if (!el) {
+            return;
+        }
+        setCanScrollLeft(el.scrollLeft > 0);
+        setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    }, []);
+
+    useEffect(() => {
+        updateScrollButtons();
+        const el = containerRef.current;
+        if (el) {
+            el.addEventListener('scroll', updateScrollButtons);
+            return () => el.removeEventListener('scroll', updateScrollButtons);
+        }
+        return undefined;
+    }, [procurements, updateScrollButtons]);
+
+    const scrollLeft = () => {
+        containerRef.current?.scrollBy({left: -SCROLL_STEP, behavior: 'smooth'});
+    };
+
+    const scrollRight = () => {
+        containerRef.current?.scrollBy({left: SCROLL_STEP, behavior: 'smooth'});
+    };
+
+    return (
+        <section className='gb-procurement-slider'>
+            <div className='gb-slider-header'>
+                <h2 className='gb-slider-title'>{'Активные закупки'}</h2>
+                <div className='gb-slider-nav'>
+                    <button
+                        className='gb-slider-nav-btn'
+                        onClick={scrollLeft}
+                        disabled={!canScrollLeft}
+                        aria-label='Прокрутить влево'
+                    >
+                        <svg
+                            width='16'
+                            height='16'
+                            viewBox='0 0 24 24'
+                            fill='none'
+                            stroke='currentColor'
+                            strokeWidth='2'
+                        >
+                            <polyline points='15 18 9 12 15 6'/>
+                        </svg>
+                    </button>
+                    <button
+                        className='gb-slider-nav-btn'
+                        onClick={scrollRight}
+                        disabled={!canScrollRight}
+                        aria-label='Прокрутить вправо'
+                    >
+                        <svg
+                            width='16'
+                            height='16'
+                            viewBox='0 0 24 24'
+                            fill='none'
+                            stroke='currentColor'
+                            strokeWidth='2'
+                        >
+                            <polyline points='9 18 15 12 9 6'/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div className='gb-slider-wrapper'>
+                <div
+                    className='gb-slider-container'
+                    ref={containerRef}
+                >
+                    {procurements.length === 0 && (
+                        <div style={{color: 'var(--tg-text-muted)', padding: '8px 0'}}>{'Загрузка закупок...'}</div>
+                    )}
+                    {procurements.map((p) => (
+                        <div
+                            key={p.id}
+                            className='gb-procurement-card'
+                            onClick={() => onCardClick(p.id)}
+                        >
+                            <div className='gb-procurement-title'>{p.title}</div>
+                            <div className='gb-procurement-info'>{p.city}</div>
+                            <div className='gb-procurement-progress'>
+                                <div
+                                    className='gb-procurement-progress-bar'
+                                    style={{width: `${p.progress}%`}}
+                                />
+                            </div>
+                            <div className='gb-procurement-stats'>
+                                <span>{`${formatCurrency(p.current_amount)} / ${formatCurrency(p.target_amount)}`}</span>
+                                <span>{`${p.days_left} дн.`}</span>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+// --- ChatList Component ---
+
+interface ChatListProps {
+    procurements: Procurement[];
+    currentChat: number | null;
+    unreadCounts: Record<number, number>;
+    onChatClick: (id: number) => void;
+}
+
+const ChatList: React.FC<ChatListProps> = ({procurements, currentChat, unreadCounts, onChatClick}) => (
+    <div className='gb-chat-list'>
+        {procurements.length === 0 && (
+            <div style={{padding: '16px', textAlign: 'center', color: 'var(--tg-text-muted)'}}>
+                {'Загрузка...'}
+            </div>
+        )}
+        {procurements.map((p) => (
+            <div
+                key={p.id}
+                className={`gb-chat-item${currentChat === p.id ? ' active' : ''}`}
+                onClick={() => onChatClick(p.id)}
+            >
+                <div
+                    className='gb-chat-avatar'
+                    style={{backgroundColor: getAvatarColor(p.title)}}
+                >
+                    {getInitials(p.title)}
+                </div>
+                <div className='gb-chat-info'>
+                    <div className='gb-chat-header-row'>
+                        <span className='gb-chat-title'>{p.title}</span>
+                        <span className='gb-chat-time'>{formatTime(p.updated_at)}</span>
+                    </div>
+                    <div className='gb-chat-message'>
+                        {`${p.participant_count} участников • ${p.progress}%`}
+                    </div>
+                </div>
+                {unreadCounts[p.id] ? (
+                    <div className='gb-chat-badge'>{unreadCounts[p.id]}</div>
+                ) : null}
+            </div>
+        ))}
+    </div>
+);
+
+// --- Cabinet Component ---
+
+interface CabinetProps {
+    user: User;
+    onDeposit: () => void;
+    onCreateProcurement: () => void;
+}
+
+const Cabinet: React.FC<CabinetProps> = ({user, onDeposit, onCreateProcurement}) => (
+    <div className='gb-cabinet'>
+        <div className='gb-cabinet-header'>
+            <div
+                className='gb-cabinet-avatar'
+                style={{backgroundColor: getAvatarColor(user.first_name)}}
+            >
+                {getInitials(user.first_name, user.last_name)}
+            </div>
+            <div>
+                <div className='gb-cabinet-name'>
+                    {`${user.first_name} ${user.last_name || ''}`}
+                </div>
+                <div className='gb-cabinet-role'>{getRoleText(user.role)}</div>
+            </div>
+        </div>
+        <div className='gb-cabinet-balance'>
+            <div className='gb-balance-label'>{'Баланс'}</div>
+            <div className='gb-balance-amount'>{formatCurrency(user.balance)}</div>
+            <div className='gb-balance-actions'>
+                <button
+                    className='gb-btn gb-btn-primary'
+                    onClick={onDeposit}
+                >
+                    {'Пополнить'}
+                </button>
+            </div>
+        </div>
+        <div className='gb-cabinet-menu'>
+            <div className='gb-cabinet-menu-item'>
+                <svg
+                    className='gb-cabinet-menu-icon'
+                    viewBox='0 0 24 24'
+                    fill='none'
+                    stroke='currentColor'
+                    strokeWidth='2'
+                >
+                    <path d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'/>
+                </svg>
+                <span className='gb-cabinet-menu-text'>{'Мои запросы'}</span>
+            </div>
+            <div className='gb-cabinet-menu-item'>
+                <svg
+                    className='gb-cabinet-menu-icon'
+                    viewBox='0 0 24 24'
+                    fill='none'
+                    stroke='currentColor'
+                    strokeWidth='2'
+                >
+                    <path d='M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z'/>
+                    <line
+                        x1='3'
+                        y1='6'
+                        x2='21'
+                        y2='6'
+                    />
+                </svg>
+                <span className='gb-cabinet-menu-text'>{'Мои закупки'}</span>
+            </div>
+            <div className='gb-cabinet-menu-item'>
+                <svg
+                    className='gb-cabinet-menu-icon'
+                    viewBox='0 0 24 24'
+                    fill='none'
+                    stroke='currentColor'
+                    strokeWidth='2'
+                >
+                    <circle
+                        cx='12'
+                        cy='12'
+                        r='10'
+                    />
+                    <polyline points='12 6 12 12 16 14'/>
+                </svg>
+                <span className='gb-cabinet-menu-text'>{'История закупок'}</span>
+            </div>
+            {user.role === 'organizer' && (
+                <div
+                    className='gb-cabinet-menu-item'
+                    onClick={onCreateProcurement}
+                >
+                    <svg
+                        className='gb-cabinet-menu-icon'
+                        viewBox='0 0 24 24'
+                        fill='none'
+                        stroke='currentColor'
+                        strokeWidth='2'
+                    >
+                        <circle
+                            cx='12'
+                            cy='12'
+                            r='10'
+                        />
+                        <line
+                            x1='12'
+                            y1='8'
+                            x2='12'
+                            y2='16'
+                        />
+                        <line
+                            x1='8'
+                            y1='12'
+                            x2='16'
+                            y2='12'
+                        />
+                    </svg>
+                    <span className='gb-cabinet-menu-text'>{'Создать закупку'}</span>
+                </div>
+            )}
+        </div>
+    </div>
+);
+
+// --- MessageArea Component ---
+
+interface MessageAreaProps {
+    messages: Message[];
+    currentUser: User | null;
+}
+
+function formatMessageDate(date: string): string {
+    const d = new Date(date);
+    const now = new Date();
+    const diff = now.getTime() - d.getTime();
+
+    if (diff < 86400000) {
+        return 'Сегодня';
+    }
+    if (diff < 172800000) {
+        return 'Вчера';
+    }
+
+    return d.toLocaleDateString('ru-RU', {
+        day: 'numeric',
+        month: 'long',
+        year: d.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+    });
+}
+
+const MessageArea: React.FC<MessageAreaProps> = ({messages, currentUser}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (containerRef.current) {
+            containerRef.current.scrollTop = containerRef.current.scrollHeight;
+        }
+    }, [messages]);
+
+    let lastDate: string | null = null;
+
+    return (
+        <div
+            className='gb-message-area'
+            ref={containerRef}
+        >
+            {messages.map((msg) => {
+                const msgDate = new Date(msg.created_at).toDateString();
+                const showDivider = msgDate !== lastDate;
+                lastDate = msgDate;
+
+                const isOwn = currentUser && msg.user && msg.user.id === currentUser.id;
+
+                return (
+                    <React.Fragment key={msg.id}>
+                        {showDivider && (
+                            <div className='gb-message-date-divider'>
+                                <span>{formatMessageDate(msg.created_at)}</span>
+                            </div>
+                        )}
+                        {msg.message_type === 'system' ? (
+                            <div className='gb-message system'>{msg.text}</div>
+                        ) : (
+                            <div className={`gb-message ${isOwn ? 'outgoing' : 'incoming'}`}>
+                                {!isOwn && msg.user && (
+                                    <div className='gb-message-sender'>{msg.user.first_name}</div>
+                                )}
+                                <div className='gb-message-text'>{msg.text}</div>
+                                <div className='gb-message-time'>{formatTime(msg.created_at)}</div>
+                            </div>
+                        )}
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+};
+
+// --- Toast Component ---
+
+interface Toast {
+    id: number;
+    message: string;
+    type: 'info' | 'success' | 'error' | 'warning';
+}
+
+// --- Main GroupBuy Component ---
+
+const GroupBuy: React.FC = () => {
+    const [appState, setAppState] = useState<AppStateType>({
+        user: null,
+        currentChat: null,
+        procurements: [],
+        messages: [],
+        isLoading: false,
+        unreadCounts: {},
+    });
+    const [activeTab, setActiveTab] = useState<'chats' | 'cabinet'>('chats');
+    const [searchQuery, setSearchQuery] = useState('');
+    const [messageText, setMessageText] = useState('');
+    const [toasts, setToasts] = useState<Toast[]>([]);
+    const [toastCounter, setToastCounter] = useState(0);
+    const [sidebarOpen, setSidebarOpen] = useState(false);
+
+    // Modal states
+    const [showLoginModal, setShowLoginModal] = useState(false);
+    const [showProcurementModal, setShowProcurementModal] = useState(false);
+    const [showCreateModal, setShowCreateModal] = useState(false);
+    const [showDepositModal, setShowDepositModal] = useState(false);
+    const [selectedProcurement, setSelectedProcurement] = useState<Procurement | null>(null);
+
+    // Register form state
+    const [registerForm, setRegisterForm] = useState({
+        first_name: '',
+        last_name: '',
+        phone: '',
+        email: '',
+        role: 'buyer',
+    });
+
+    // Create procurement form state
+    const [createForm, setCreateForm] = useState({
+        title: '',
+        description: '',
+        city: '',
+        target_amount: '',
+        unit: '',
+        deadline: '',
+    });
+
+    const [depositAmount, setDepositAmount] = useState('');
+
+    const showToast = useCallback((message: string, type: Toast['type'] = 'info') => {
+        const id = toastCounter + 1;
+        setToastCounter(id);
+        setToasts((prev) => [...prev, {id, message, type}]);
+        setTimeout(() => {
+            setToasts((prev) => prev.filter((t) => t.id !== id));
+        }, 3000);
+    }, [toastCounter]);
+
+    const loadMainContent = useCallback(async (user: User) => {
+        try {
+            const response = await API.getProcurements({status: 'active'});
+            const procurements = Array.isArray(response) ? response : (response.results || []);
+            setAppState((prev) => ({...prev, procurements, user}));
+        } catch {
+            console.error('Error loading procurements');
+        }
+    }, []);
+
+    useEffect(() => {
+        const userId = localStorage.getItem('groupbuy_userId');
+        if (userId) {
+            API.getUser(parseInt(userId)).
+                then((user) => loadMainContent(user)).
+                catch(() => setShowLoginModal(true));
+        } else {
+            setShowLoginModal(true);
+        }
+    }, [loadMainContent]);
+
+    const handleRegister = async () => {
+        try {
+            const user = await API.registerUser({
+                ...registerForm,
+                platform: 'websocket',
+                balance: 0,
+            });
+            localStorage.setItem('groupbuy_userId', String(user.id));
+            setShowLoginModal(false);
+            await loadMainContent(user);
+            showToast('Регистрация успешна', 'success');
+        } catch {
+            showToast('Ошибка регистрации', 'error');
+        }
+    };
+
+    const handleOpenChat = useCallback(async (procurementId: number) => {
+        setAppState((prev) => ({
+            ...prev,
+            currentChat: procurementId,
+            unreadCounts: {...prev.unreadCounts, [procurementId]: 0},
+        }));
+        setSidebarOpen(false);
+
+        try {
+            const response = await API.getMessages(procurementId);
+            const messages = Array.isArray(response) ? response : (response.results || []);
+            setAppState((prev) => ({...prev, messages}));
+        } catch {
+            showToast('Ошибка загрузки сообщений', 'error');
+        }
+    }, [showToast]);
+
+    const handleOpenProcurementDetails = useCallback(async (id: number) => {
+        try {
+            const procurement = await API.getProcurement(id);
+            setSelectedProcurement(procurement);
+            setShowProcurementModal(true);
+        } catch {
+            showToast('Ошибка загрузки закупки', 'error');
+        }
+    }, [showToast]);
+
+    const handleSendMessage = async () => {
+        const text = messageText.trim();
+        if (!text || !appState.currentChat || !appState.user) {
+            return;
+        }
+
+        try {
+            const message = await API.sendMessage({
+                procurement: appState.currentChat,
+                user: appState.user,
+                text,
+                message_type: 'text',
+                created_at: new Date().toISOString(),
+            });
+            setAppState((prev) => ({...prev, messages: [...prev.messages, message]}));
+            setMessageText('');
+        } catch {
+            showToast('Ошибка отправки сообщения', 'error');
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleSendMessage();
+        }
+    };
+
+    const handleJoinProcurement = async () => {
+        if (!selectedProcurement || !appState.user) {
+            return;
+        }
+        try {
+            await API.joinProcurement(selectedProcurement.id, {user: appState.user.id});
+            setShowProcurementModal(false);
+            showToast('Вы присоединились к закупке', 'success');
+            await handleOpenChat(selectedProcurement.id);
+        } catch {
+            showToast('Ошибка при вступлении в закупку', 'error');
+        }
+    };
+
+    const handleCreateProcurement = async () => {
+        try {
+            await API.createProcurement({
+                ...createForm,
+                target_amount: parseFloat(createForm.target_amount),
+            });
+            setShowCreateModal(false);
+            showToast('Закупка создана', 'success');
+            if (appState.user) {
+                await loadMainContent(appState.user);
+            }
+        } catch {
+            showToast('Ошибка создания закупки', 'error');
+        }
+    };
+
+    const handleDeposit = async () => {
+        if (!appState.user) {
+            return;
+        }
+        try {
+            await API.deposit(appState.user.id, parseFloat(depositAmount));
+            setShowDepositModal(false);
+            setDepositAmount('');
+            showToast('Баланс пополнен', 'success');
+        } catch {
+            showToast('Ошибка пополнения баланса', 'error');
+        }
+    };
+
+    const filteredProcurements = searchQuery.trim() ?
+        appState.procurements.filter(
+            (p) => p.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                p.city.toLowerCase().includes(searchQuery.toLowerCase()),
+        ) : appState.procurements;
+
+    const currentChatProcurement = appState.currentChat ?
+        appState.procurements.find((p) => p.id === appState.currentChat) : null;
+
+    return (
+        <div className='groupbuy-app'>
+            {/* Sidebar */}
+            <aside className={`gb-sidebar${sidebarOpen ? ' open' : ''}`}>
+                <header className='gb-header'>
+                    <button
+                        className='gb-btn gb-btn-icon'
+                        onClick={() => setSidebarOpen(!sidebarOpen)}
+                        aria-label='Меню'
+                    >
+                        <svg
+                            width='24'
+                            height='24'
+                            viewBox='0 0 24 24'
+                            fill='none'
+                            stroke='currentColor'
+                            strokeWidth='2'
+                        >
+                            <line
+                                x1='3'
+                                y1='12'
+                                x2='21'
+                                y2='12'
+                            />
+                            <line
+                                x1='3'
+                                y1='6'
+                                x2='21'
+                                y2='6'
+                            />
+                            <line
+                                x1='3'
+                                y1='18'
+                                x2='21'
+                                y2='18'
+                            />
+                        </svg>
+                    </button>
+                    <h1 className='gb-header-title'>{'GroupBuy'}</h1>
+                </header>
+
+                <div className='gb-search-bar'>
+                    <svg
+                        className='gb-search-icon'
+                        viewBox='0 0 24 24'
+                        fill='none'
+                        stroke='currentColor'
+                        strokeWidth='2'
+                    >
+                        <circle
+                            cx='11'
+                            cy='11'
+                            r='8'
+                        />
+                        <line
+                            x1='21'
+                            y1='21'
+                            x2='16.65'
+                            y2='16.65'
+                        />
+                    </svg>
+                    <input
+                        type='text'
+                        className='gb-search-input'
+                        placeholder='Поиск...'
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                    />
+                </div>
+
+                <div className='gb-tabs'>
+                    <button
+                        className={`gb-tab${activeTab === 'chats' ? ' active' : ''}`}
+                        onClick={() => setActiveTab('chats')}
+                    >
+                        {'Чаты'}
+                    </button>
+                    <button
+                        className={`gb-tab${activeTab === 'cabinet' ? ' active' : ''}`}
+                        onClick={() => setActiveTab('cabinet')}
+                    >
+                        {'Кабинет'}
+                    </button>
+                </div>
+
+                {activeTab === 'chats' && (
+                    <ChatList
+                        procurements={filteredProcurements}
+                        currentChat={appState.currentChat}
+                        unreadCounts={appState.unreadCounts}
+                        onChatClick={handleOpenChat}
+                    />
+                )}
+
+                {activeTab === 'cabinet' && appState.user && (
+                    <Cabinet
+                        user={appState.user}
+                        onDeposit={() => setShowDepositModal(true)}
+                        onCreateProcurement={() => setShowCreateModal(true)}
+                    />
+                )}
+            </aside>
+
+            {/* Main content */}
+            <main className='gb-main-content'>
+                <ProcurementSlider
+                    procurements={appState.procurements}
+                    onCardClick={handleOpenProcurementDetails}
+                />
+
+                {appState.currentChat ? (
+                    <>
+                        <header className='gb-header'>
+                            <button
+                                className='gb-btn gb-btn-icon'
+                                onClick={() => setAppState((prev) => ({...prev, currentChat: null, messages: []}))}
+                                aria-label='Назад'
+                            >
+                                <svg
+                                    width='24'
+                                    height='24'
+                                    viewBox='0 0 24 24'
+                                    fill='none'
+                                    stroke='currentColor'
+                                    strokeWidth='2'
+                                >
+                                    <polyline points='15 18 9 12 15 6'/>
+                                </svg>
+                            </button>
+                            {currentChatProcurement && (
+                                <div
+                                    className='gb-chat-avatar'
+                                    style={{
+                                        backgroundColor: getAvatarColor(currentChatProcurement.title),
+                                        width: '36px',
+                                        height: '36px',
+                                        fontSize: '14px',
+                                    }}
+                                >
+                                    {getInitials(currentChatProcurement.title)}
+                                </div>
+                            )}
+                            <div>
+                                <div className='gb-header-title'>
+                                    {currentChatProcurement?.title || 'Чат'}
+                                </div>
+                                {currentChatProcurement && (
+                                    <div className='gb-header-subtitle'>
+                                        {`${currentChatProcurement.participant_count} участников`}
+                                    </div>
+                                )}
+                            </div>
+                            {currentChatProcurement && (
+                                <button
+                                    className='gb-btn gb-btn-icon'
+                                    onClick={() => handleOpenProcurementDetails(appState.currentChat!)}
+                                    aria-label='Подробнее'
+                                    style={{marginLeft: 'auto'}}
+                                >
+                                    <svg
+                                        width='20'
+                                        height='20'
+                                        viewBox='0 0 24 24'
+                                        fill='none'
+                                        stroke='currentColor'
+                                        strokeWidth='2'
+                                    >
+                                        <circle
+                                            cx='12'
+                                            cy='12'
+                                            r='1'
+                                        />
+                                        <circle
+                                            cx='12'
+                                            cy='5'
+                                            r='1'
+                                        />
+                                        <circle
+                                            cx='12'
+                                            cy='19'
+                                            r='1'
+                                        />
+                                    </svg>
+                                </button>
+                            )}
+                        </header>
+
+                        <MessageArea
+                            messages={appState.messages}
+                            currentUser={appState.user}
+                        />
+
+                        <div className='gb-message-input-area'>
+                            <button
+                                className='gb-btn gb-btn-icon'
+                                aria-label='Прикрепить файл'
+                            >
+                                <svg
+                                    width='24'
+                                    height='24'
+                                    viewBox='0 0 24 24'
+                                    fill='none'
+                                    stroke='currentColor'
+                                    strokeWidth='2'
+                                >
+                                    <path d='M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48'/>
+                                </svg>
+                            </button>
+                            <div className='gb-message-input-container'>
+                                <textarea
+                                    className='gb-message-input'
+                                    placeholder='Сообщение...'
+                                    rows={1}
+                                    value={messageText}
+                                    onChange={(e) => setMessageText(e.target.value)}
+                                    onKeyDown={handleKeyDown}
+                                />
+                            </div>
+                            <button
+                                className='gb-send-button'
+                                onClick={handleSendMessage}
+                                aria-label='Отправить'
+                            >
+                                <svg
+                                    width='24'
+                                    height='24'
+                                    viewBox='0 0 24 24'
+                                    fill='none'
+                                    stroke='currentColor'
+                                    strokeWidth='2'
+                                >
+                                    <line
+                                        x1='22'
+                                        y1='2'
+                                        x2='11'
+                                        y2='13'
+                                    />
+                                    <polygon points='22 2 15 22 11 13 2 9 22 2'/>
+                                </svg>
+                            </button>
+                        </div>
+                    </>
+                ) : (
+                    <div className='gb-welcome-screen'>
+                        <svg
+                            width='120'
+                            height='120'
+                            viewBox='0 0 24 24'
+                            fill='none'
+                            stroke='currentColor'
+                            strokeWidth='1.5'
+                        >
+                            <path d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'/>
+                        </svg>
+                        <h2>{'Добро пожаловать в GroupBuy'}</h2>
+                        <p>{'Выберите закупку или создайте новую'}</p>
+                    </div>
+                )}
+            </main>
+
+            {/* Login Modal */}
+            {showLoginModal && (
+                <div className='gb-modal-overlay active'>
+                    <div className='gb-modal'>
+                        <div className='gb-modal-header'>
+                            <h3 className='gb-modal-title'>{'Регистрация'}</h3>
+                        </div>
+                        <div className='gb-modal-body'>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Имя *'}</label>
+                                <input
+                                    type='text'
+                                    className='gb-form-input'
+                                    placeholder='Введите имя'
+                                    value={registerForm.first_name}
+                                    onChange={(e) => setRegisterForm((f) => ({...f, first_name: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Фамилия'}</label>
+                                <input
+                                    type='text'
+                                    className='gb-form-input'
+                                    placeholder='Введите фамилию'
+                                    value={registerForm.last_name}
+                                    onChange={(e) => setRegisterForm((f) => ({...f, last_name: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Телефон'}</label>
+                                <input
+                                    type='tel'
+                                    className='gb-form-input'
+                                    placeholder='+7 999 123 4567'
+                                    value={registerForm.phone}
+                                    onChange={(e) => setRegisterForm((f) => ({...f, phone: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Email'}</label>
+                                <input
+                                    type='email'
+                                    className='gb-form-input'
+                                    placeholder='email@example.com'
+                                    value={registerForm.email}
+                                    onChange={(e) => setRegisterForm((f) => ({...f, email: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Роль *'}</label>
+                                <select
+                                    className='gb-form-input'
+                                    value={registerForm.role}
+                                    onChange={(e) => setRegisterForm((f) => ({...f, role: e.target.value}))}
+                                    style={{height: '44px', cursor: 'pointer'}}
+                                >
+                                    <option value='buyer'>{'Покупатель'}</option>
+                                    <option value='organizer'>{'Организатор'}</option>
+                                    <option value='supplier'>{'Поставщик'}</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div className='gb-modal-footer'>
+                            <button
+                                className='gb-btn gb-btn-primary'
+                                onClick={handleRegister}
+                                disabled={!registerForm.first_name}
+                            >
+                                {'Зарегистрироваться'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Procurement Details Modal */}
+            {showProcurementModal && selectedProcurement && (
+                <div
+                    className='gb-modal-overlay active'
+                    onClick={(e) => {
+                        if (e.target === e.currentTarget) {
+                            setShowProcurementModal(false);
+                        }
+                    }}
+                >
+                    <div className='gb-modal'>
+                        <div className='gb-modal-header'>
+                            <h3 className='gb-modal-title'>{selectedProcurement.title}</h3>
+                            <button
+                                className='gb-btn gb-btn-icon'
+                                onClick={() => setShowProcurementModal(false)}
+                            >
+                                <svg
+                                    width='24'
+                                    height='24'
+                                    viewBox='0 0 24 24'
+                                    fill='none'
+                                    stroke='currentColor'
+                                    strokeWidth='2'
+                                >
+                                    <line
+                                        x1='18'
+                                        y1='6'
+                                        x2='6'
+                                        y2='18'
+                                    />
+                                    <line
+                                        x1='6'
+                                        y1='6'
+                                        x2='18'
+                                        y2='18'
+                                    />
+                                </svg>
+                            </button>
+                        </div>
+                        <div className='gb-modal-body'>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Описание'}</label>
+                                <p style={{color: 'var(--tg-text-primary)', lineHeight: '1.5'}}>{selectedProcurement.description}</p>
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Город'}</label>
+                                <p style={{color: 'var(--tg-text-primary)'}}>{selectedProcurement.city}</p>
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Прогресс'}</label>
+                                <div className='gb-procurement-progress' style={{marginTop: '8px'}}>
+                                    <div
+                                        className='gb-procurement-progress-bar'
+                                        style={{width: `${selectedProcurement.progress}%`}}
+                                    />
+                                </div>
+                                <p style={{marginTop: '8px', color: 'var(--tg-text-secondary)'}}>
+                                    {`${formatCurrency(selectedProcurement.current_amount)} из ${formatCurrency(selectedProcurement.target_amount)}`}
+                                </p>
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Участники'}</label>
+                                <p style={{color: 'var(--tg-text-primary)'}}>{`${selectedProcurement.participant_count} человек`}</p>
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Статус'}</label>
+                                <span className={`gb-status-badge status-${selectedProcurement.status}`}>
+                                    {getStatusText(selectedProcurement.status)}
+                                </span>
+                            </div>
+                        </div>
+                        <div className='gb-modal-footer'>
+                            <button
+                                className='gb-btn gb-btn-secondary'
+                                onClick={() => setShowProcurementModal(false)}
+                            >
+                                {'Закрыть'}
+                            </button>
+                            <button
+                                className='gb-btn gb-btn-primary'
+                                onClick={handleJoinProcurement}
+                            >
+                                {'Участвовать'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Create Procurement Modal */}
+            {showCreateModal && (
+                <div
+                    className='gb-modal-overlay active'
+                    onClick={(e) => {
+                        if (e.target === e.currentTarget) {
+                            setShowCreateModal(false);
+                        }
+                    }}
+                >
+                    <div className='gb-modal'>
+                        <div className='gb-modal-header'>
+                            <h3 className='gb-modal-title'>{'Создать закупку'}</h3>
+                            <button
+                                className='gb-btn gb-btn-icon'
+                                onClick={() => setShowCreateModal(false)}
+                            >
+                                <svg
+                                    width='24'
+                                    height='24'
+                                    viewBox='0 0 24 24'
+                                    fill='none'
+                                    stroke='currentColor'
+                                    strokeWidth='2'
+                                >
+                                    <line
+                                        x1='18'
+                                        y1='6'
+                                        x2='6'
+                                        y2='18'
+                                    />
+                                    <line
+                                        x1='6'
+                                        y1='6'
+                                        x2='18'
+                                        y2='18'
+                                    />
+                                </svg>
+                            </button>
+                        </div>
+                        <div className='gb-modal-body'>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Название товара *'}</label>
+                                <input
+                                    type='text'
+                                    className='gb-form-input'
+                                    placeholder='Например: Мед натуральный'
+                                    value={createForm.title}
+                                    onChange={(e) => setCreateForm((f) => ({...f, title: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Описание *'}</label>
+                                <textarea
+                                    className='gb-form-input'
+                                    placeholder='Подробное описание закупки...'
+                                    style={{height: '80px', paddingTop: '10px', resize: 'vertical'}}
+                                    value={createForm.description}
+                                    onChange={(e) => setCreateForm((f) => ({...f, description: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Город получения *'}</label>
+                                <input
+                                    type='text'
+                                    className='gb-form-input'
+                                    placeholder='Москва'
+                                    value={createForm.city}
+                                    onChange={(e) => setCreateForm((f) => ({...f, city: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Целевая сумма (руб.) *'}</label>
+                                <input
+                                    type='number'
+                                    className='gb-form-input'
+                                    placeholder='10000'
+                                    min='1000'
+                                    value={createForm.target_amount}
+                                    onChange={(e) => setCreateForm((f) => ({...f, target_amount: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Единица измерения'}</label>
+                                <input
+                                    type='text'
+                                    className='gb-form-input'
+                                    placeholder='кг, шт, л'
+                                    value={createForm.unit}
+                                    onChange={(e) => setCreateForm((f) => ({...f, unit: e.target.value}))}
+                                />
+                            </div>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Дедлайн *'}</label>
+                                <input
+                                    type='datetime-local'
+                                    className='gb-form-input'
+                                    value={createForm.deadline}
+                                    onChange={(e) => setCreateForm((f) => ({...f, deadline: e.target.value}))}
+                                />
+                            </div>
+                        </div>
+                        <div className='gb-modal-footer'>
+                            <button
+                                className='gb-btn gb-btn-secondary'
+                                onClick={() => setShowCreateModal(false)}
+                            >
+                                {'Отмена'}
+                            </button>
+                            <button
+                                className='gb-btn gb-btn-primary'
+                                onClick={handleCreateProcurement}
+                                disabled={!createForm.title || !createForm.description || !createForm.city || !createForm.target_amount || !createForm.deadline}
+                            >
+                                {'Создать'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Deposit Modal */}
+            {showDepositModal && (
+                <div
+                    className='gb-modal-overlay active'
+                    onClick={(e) => {
+                        if (e.target === e.currentTarget) {
+                            setShowDepositModal(false);
+                        }
+                    }}
+                >
+                    <div className='gb-modal'>
+                        <div className='gb-modal-header'>
+                            <h3 className='gb-modal-title'>{'Пополнение баланса'}</h3>
+                            <button
+                                className='gb-btn gb-btn-icon'
+                                onClick={() => setShowDepositModal(false)}
+                            >
+                                <svg
+                                    width='24'
+                                    height='24'
+                                    viewBox='0 0 24 24'
+                                    fill='none'
+                                    stroke='currentColor'
+                                    strokeWidth='2'
+                                >
+                                    <line
+                                        x1='18'
+                                        y1='6'
+                                        x2='6'
+                                        y2='18'
+                                    />
+                                    <line
+                                        x1='6'
+                                        y1='6'
+                                        x2='18'
+                                        y2='18'
+                                    />
+                                </svg>
+                            </button>
+                        </div>
+                        <div className='gb-modal-body'>
+                            <div className='gb-form-group'>
+                                <label className='gb-form-label'>{'Сумма (руб.) *'}</label>
+                                <input
+                                    type='number'
+                                    className='gb-form-input'
+                                    placeholder='1000'
+                                    min='100'
+                                    value={depositAmount}
+                                    onChange={(e) => setDepositAmount(e.target.value)}
+                                />
+                            </div>
+                            <p style={{color: 'var(--tg-text-secondary)', fontSize: '12px', marginTop: '8px'}}>
+                                {'Минимальная сумма пополнения: 100 руб.'}
+                            </p>
+                        </div>
+                        <div className='gb-modal-footer'>
+                            <button
+                                className='gb-btn gb-btn-secondary'
+                                onClick={() => setShowDepositModal(false)}
+                            >
+                                {'Отмена'}
+                            </button>
+                            <button
+                                className='gb-btn gb-btn-primary'
+                                onClick={handleDeposit}
+                                disabled={!depositAmount || parseFloat(depositAmount) < 100}
+                            >
+                                {'Пополнить'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Toast container */}
+            <div className='gb-toast-container'>
+                {toasts.map((toast) => (
+                    <div
+                        key={toast.id}
+                        className={`gb-toast ${toast.type}`}
+                    >
+                        {toast.message}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default GroupBuy;

--- a/mattermost-master/webapp/channels/src/components/groupbuy/index.ts
+++ b/mattermost-master/webapp/channels/src/components/groupbuy/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export {default} from './groupbuy';

--- a/mattermost-master/webapp/channels/src/components/groupbuy/types.ts
+++ b/mattermost-master/webapp/channels/src/components/groupbuy/types.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export type ProcurementStatus = 'draft' | 'active' | 'stopped' | 'payment' | 'completed' | 'cancelled';
+
+export type UserRole = 'buyer' | 'organizer' | 'supplier';
+
+export interface Procurement {
+    id: number;
+    title: string;
+    description: string;
+    city: string;
+    category?: string;
+    target_amount: number;
+    current_amount: number;
+    unit?: string;
+    deadline: string;
+    status: ProcurementStatus;
+    progress: number;
+    participant_count: number;
+    days_left: number;
+    updated_at: string;
+}
+
+export interface User {
+    id: number;
+    first_name: string;
+    last_name?: string;
+    phone?: string;
+    email?: string;
+    role: UserRole;
+    balance: number;
+    platform?: string;
+}
+
+export interface Message {
+    id: number;
+    procurement: number;
+    user?: User;
+    text: string;
+    message_type: 'text' | 'system';
+    created_at: string;
+}
+
+export interface AppStateType {
+    user: User | null;
+    currentChat: number | null;
+    procurements: Procurement[];
+    messages: Message[];
+    isLoading: boolean;
+    unreadCounts: Record<number, number>;
+}

--- a/mattermost-master/webapp/channels/src/components/root/root.tsx
+++ b/mattermost-master/webapp/channels/src/components/root/root.tsx
@@ -76,6 +76,7 @@ const ModalController = makeAsyncComponent('ModalController', lazy(() => import(
 const AppBar = makeAsyncComponent('AppBar', lazy(() => import('components/app_bar/app_bar')));
 const ComponentLibrary = makeAsyncComponent('ComponentLibrary', lazy(() => import('components/component_library')));
 const PopoutController = makeAsyncComponent('PopoutController', lazy(() => import('components/popout_controller')));
+const GroupBuy = makeAsyncComponent('GroupBuy', lazy(() => import('components/groupbuy')));
 
 const Pluggable = makeAsyncPluggableComponent();
 
@@ -387,6 +388,10 @@ export default class Root extends React.PureComponent<Props, State> {
                     <LoggedInRoute
                         path={'/mfa'}
                         component={Mfa}
+                    />
+                    <Route
+                        path={'/groupbuy'}
+                        component={GroupBuy}
                     />
                     <LoggedInRoute
                         path={'/preparing-workspace'}


### PR DESCRIPTION
## Summary

Fixes MixaByk1996/mattermost#7

This PR integrates the layout and functionality from [groupbuy-bot](https://github.com/MixaByk1996/groupbuy-bot) into the Mattermost webapp as a React/TypeScript component.

### Changes

- **New component**: `webapp/channels/src/components/groupbuy/` — A full Telegram-style GroupBuy interface ported to React
  - `groupbuy.tsx` — Main React component with all UI logic
  - `groupbuy.scss` — Telegram-style CSS design system (scoped under `.groupbuy-app`)
  - `types.ts` — TypeScript type definitions for `Procurement`, `User`, `Message`
  - `index.ts` — Re-export for lazy loading

- **Route integration**: Added `/groupbuy` route in `root.tsx` — accessible at `{siteURL}/groupbuy`

### Features

- Sidebar with chat list (procurement rooms) and personal cabinet
- Search bar for filtering procurements
- Role-based cabinet menu (buyer / organizer / supplier)
- Registration modal
- Procurement details modal with join action
- Create procurement modal (for organizers)
- Balance deposit modal
- Real-time messaging area with WebSocket-ready API client
- Dark/light theme support

### Slider Fix

The original groupbuy-bot slider (`procurement-slider`) only used `overflow-x: auto` with no navigation controls, making it difficult to scroll on non-touch devices.

**Fix**: Added prev/next navigation buttons (`←` / `→`) to the `ProcurementSlider` component that:
- Scroll the container by a fixed step (220px) with smooth animation
- Disable when scroll is not possible in that direction
- Visually highlight on hover when enabled

## Test plan

- [ ] Navigate to `/groupbuy` in a running Mattermost instance
- [ ] Verify the GroupBuy UI renders with the Telegram-like design
- [ ] Verify the procurement slider shows left/right navigation buttons
- [ ] Verify buttons disable correctly at the ends of the slider
- [ ] Verify registration modal appears on first visit
- [ ] Verify chat list, cabinet tabs switch correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)